### PR TITLE
Path for ceph config missing in crash template

### DIFF
--- a/roles/ceph-crash/templates/ceph-crash.service.j2
+++ b/roles/ceph-crash/templates/ceph-crash.service.j2
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/{{ container_binary }} run --rm --name ceph-crash-%i \
 --net=host \
 -v /var/lib/ceph:/var/lib/ceph:z \
 -v /etc/localtime:/etc/localtime:ro \
+-v /etc/ceph:/etc/ceph:z \
 --entrypoint=/usr/bin/ceph-crash {{ ceph_docker_registry }}/{{ ceph_docker_image }}:{{ ceph_docker_image_tag }}
 {% if container_binary == 'podman' %}
 ExecStop=-/usr/bin/sh -c "/usr/bin/{{ container_binary }} rm -f `cat /%t/%n-cid`"


### PR DESCRIPTION
The path where ceph.conf is located (/etc/ceph) missing in the Docker container bind mounts, this throws errors